### PR TITLE
fix: proxy Umami analytics to bypass ad blockers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,14 @@
 
 [build.environment]
   NODE_VERSION = "22"
+
+# Proxy Umami Cloud through our domain to avoid ad-blocker blocklists
+[[redirects]]
+  from = "/u/script.js"
+  to = "https://cloud.umami.is/script.js"
+  status = 200
+
+[[redirects]]
+  from = "/u/api/send"
+  to = "https://cloud.umami.is/api/send"
+  status = 200

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -42,8 +42,8 @@ const ogImageURL = new URL(ogImage, Astro.site ?? "https://deflocksc.netlify.app
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800;900&display=swap" rel="stylesheet" />
 
-    {/* Umami Cloud Analytics – privacy-friendly, cookie-free, GDPR-compliant */}
-    <script defer src="https://cloud.umami.is/script.js" data-website-id="c0ff812f-a062-43e1-8ac1-e5eafd527ffc" />
+    {/* Umami Cloud Analytics – proxied through our domain to avoid ad-blocker blocklists */}
+    <script defer src="/u/script.js" data-website-id="c0ff812f-a062-43e1-8ac1-e5eafd527ffc" />
   </head>
   <body class="bg-[#171717] text-[#d4d4d4] font-['Inter',sans-serif] leading-[1.7] min-h-screen">
     <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:bg-[#dc2626] focus:text-white focus:font-bold focus:text-sm focus:px-4 focus:py-2 focus:rounded">


### PR DESCRIPTION
## Summary
- Added Netlify proxy rewrites (`/u/script.js` → `cloud.umami.is/script.js`, `/u/api/send` → `cloud.umami.is/api/send`) so the analytics script loads from our own domain
- Updated the script tag in `Base.astro` to use the proxied path
- Ad blockers block `cloud.umami.is` by domain — serving from `deflocksc.org/u/*` makes it indistinguishable from first-party JS

## Test plan
- [ ] Deploy to Netlify preview and verify `/u/script.js` returns the Umami script (not a 404)
- [ ] Verify `umami` global is defined in the browser console after page load
- [ ] Confirm page views appear in the Umami Cloud dashboard
- [ ] Verify with an ad blocker enabled that analytics still load

🤖 Generated with [Claude Code](https://claude.com/claude-code)