### PR TITLE
Remove glitch scan line animation from Hero

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -55,12 +55,6 @@
     </div>
   </div>
 
-  <!-- Glitch scan bars -->
-  <div class="absolute inset-0 overflow-hidden pointer-events-none" aria-hidden="true">
-    <div class="glitch-bar absolute left-0 right-0 h-[2px] bg-[rgba(220,38,38,0.15)]"></div>
-    <div class="glitch-bar2 absolute left-0 right-0 h-[1px] bg-[rgba(255,255,255,0.04)]"></div>
-  </div>
-
   <!-- Top metadata bar -->
   <div class="hidden md:flex relative z-10 px-6 md:px-12 justify-between items-start pointer-events-none" aria-hidden="true">
     <div class="text-[11px] uppercase tracking-[0.12em] leading-[1.8]">
@@ -102,22 +96,6 @@
 </section>
 
 <style>
-  @keyframes glitch-scan {
-    0%   { top: -2px; opacity: 0; }
-    5%   { opacity: 1; }
-    95%  { opacity: 0.3; }
-    100% { top: 100%; opacity: 0; }
-  }
-  @keyframes glitch-scan2 {
-    0%   { top: -1px; }
-    100% { top: 100%; }
-  }
-  .glitch-bar  { animation: glitch-scan  8s linear infinite; }
-  .glitch-bar2 { animation: glitch-scan2 5s linear infinite 2s; }
-  @media (prefers-reduced-motion: reduce) {
-    .glitch-bar, .glitch-bar2 { animation: none; }
-  }
-
   @keyframes cone-sweep {
     0%   { transform: rotate(-20deg); animation-timing-function: ease-in-out; }
     38%  { transform: rotate(18deg);  animation-timing-function: cubic-bezier(0.7, 0, 0.3, 1); }


### PR DESCRIPTION
Drops the two animated scan bars and their keyframes from the home
page hero — the effect felt visually noisy without adding meaning.

https://claude.ai/code/session_01QUdBg6VXbxgYSFWBMzeYD8