### PR TITLE
fix(blog): stack hero title under image on mobile to prevent nav overlap

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -28,6 +28,11 @@ const ogImage = post.data.ogImage
 
 // Filter headings to h2 and h3 for TOC
 const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
+
+// Shrink the title when it's long enough to risk overflowing the hero overlay
+const titleSizeClass = post.data.title.length > 65
+  ? 'text-2xl md:text-3xl'
+  : 'text-3xl md:text-4xl';
 ---
 
 <Base title={`${post.data.title} — DeflockSC`} description={post.data.summary} ogImage={ogImage} ogType="article" publishedDate={new Date(post.data.date).toISOString()}>
@@ -84,17 +89,17 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
     {/* Back link */}
     <a href="/blog" class="hidden md:block absolute top-20 left-6 lg:left-10 text-[#fbbf24] hover:text-[#fcd34d] text-sm font-medium transition-colors z-10 [text-shadow:0_1px_8px_rgba(0,0,0,0.8)]">&larr; Back to Blog</a>
 
-    {/* Title + meta — flows below image on mobile, overlays image on desktop */}
-    <div class="px-6 lg:px-10 pt-6 pb-6 md:pt-0 md:pb-8 md:absolute md:bottom-0 md:left-0 md:right-0">
+    {/* Title + meta overlay */}
+    <div class="absolute bottom-0 left-0 right-0 px-6 lg:px-10 pb-6 md:pb-8">
       <div class="max-w-[660px] mx-auto lg:mx-0 lg:ml-[calc((100%-660px-240px-2.5rem)/2)] min-w-0">
-        <div class="flex items-center gap-3 label-mono-compact text-[#a0a0a0] mb-2.5 md:[text-shadow:0_2px_12px_rgba(0,0,0,0.9)]">
+        <div class="flex items-center gap-3 label-mono-compact text-[#a0a0a0] mb-2.5 [text-shadow:0_2px_12px_rgba(0,0,0,0.9)]">
           <time datetime={new Date(post.data.date).toISOString()}>
             {new Date(post.data.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}
           </time>
           <span class="text-[rgba(255,255,255,0.25)]">/</span>
           <span>{readTime} min read</span>
         </div>
-        <h1 class="text-3xl md:text-4xl font-bold text-[#e8e8e8] leading-tight tracking-[-0.02em] break-words md:[text-shadow:0_2px_20px_rgba(0,0,0,0.9),0_4px_40px_rgba(0,0,0,0.7)]">{post.data.title}</h1>
+        <h1 class={`${titleSizeClass} font-bold text-[#e8e8e8] leading-tight tracking-[-0.02em] break-words [text-shadow:0_2px_20px_rgba(0,0,0,0.9),0_4px_40px_rgba(0,0,0,0.7)]`}>{post.data.title}</h1>
       </div>
     </div>
   </div>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -84,19 +84,19 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
     {/* Back link */}
     <a href="/blog" class="hidden md:block absolute top-20 left-6 lg:left-10 text-[#fbbf24] hover:text-[#fcd34d] text-sm font-medium transition-colors z-10 [text-shadow:0_1px_8px_rgba(0,0,0,0.8)]">&larr; Back to Blog</a>
 
-    {/* Title + meta overlay */}
-    <div class="absolute bottom-0 left-0 right-0 px-6 lg:px-10 pb-6 md:pb-8">
-      <div class="max-w-[660px] mx-auto lg:mx-0 lg:ml-[calc((100%-660px-240px-2.5rem)/2)]">
-        <div class="flex items-center gap-3 label-mono-compact text-[#a0a0a0] mb-2.5 [text-shadow:0_2px_12px_rgba(0,0,0,0.9)]">
+    {/* Title + meta — flows below image on mobile, overlays image on desktop */}
+    <div class="px-6 lg:px-10 pt-6 pb-6 md:pt-0 md:pb-8 md:absolute md:bottom-0 md:left-0 md:right-0">
+      <div class="max-w-[660px] mx-auto lg:mx-0 lg:ml-[calc((100%-660px-240px-2.5rem)/2)] min-w-0">
+        <div class="flex items-center gap-3 label-mono-compact text-[#a0a0a0] mb-2.5 md:[text-shadow:0_2px_12px_rgba(0,0,0,0.9)]">
           <time datetime={new Date(post.data.date).toISOString()}>
             {new Date(post.data.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}
           </time>
           <span class="text-[rgba(255,255,255,0.25)]">/</span>
           <span>{readTime} min read</span>
         </div>
-        <h1 class="text-3xl md:text-4xl font-bold text-[#e8e8e8] leading-tight tracking-[-0.02em] [text-shadow:0_2px_20px_rgba(0,0,0,0.9),0_4px_40px_rgba(0,0,0,0.7)]">{post.data.title}</h1>
+        <h1 class="text-3xl md:text-4xl font-bold text-[#e8e8e8] leading-tight tracking-[-0.02em] break-words md:[text-shadow:0_2px_20px_rgba(0,0,0,0.9),0_4px_40px_rgba(0,0,0,0.7)]">{post.data.title}</h1>
         {post.data.subtitle && (
-          <p class="text-lg md:text-xl text-[#a0a0a0] mt-2 font-medium leading-snug [text-shadow:0_2px_12px_rgba(0,0,0,0.9)]">{post.data.subtitle}</p>
+          <p class="text-lg md:text-xl text-[#a0a0a0] mt-2 font-medium leading-snug break-words md:[text-shadow:0_2px_12px_rgba(0,0,0,0.9)]">{post.data.subtitle}</p>
         )}
       </div>
     </div>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -95,9 +95,6 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
           <span>{readTime} min read</span>
         </div>
         <h1 class="text-3xl md:text-4xl font-bold text-[#e8e8e8] leading-tight tracking-[-0.02em] break-words md:[text-shadow:0_2px_20px_rgba(0,0,0,0.9),0_4px_40px_rgba(0,0,0,0.7)]">{post.data.title}</h1>
-        {post.data.subtitle && (
-          <p class="text-lg md:text-xl text-[#a0a0a0] mt-2 font-medium leading-snug break-words md:[text-shadow:0_2px_12px_rgba(0,0,0,0.9)]">{post.data.subtitle}</p>
-        )}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Long titles in the absolutely-positioned hero overlay extended above
their bottom anchor, colliding with the fixed nav. The overlay now
flows in normal document order on mobile and only switches to the
absolute overlay treatment at md+, where the hero has a fixed height.
Text shadows are scoped to the desktop overlay since they're not
needed when the title sits on the solid hero background.